### PR TITLE
chore(remove-experience-hover): removing hover color change for experience cards

### DIFF
--- a/styles/Experience.module.css
+++ b/styles/Experience.module.css
@@ -20,10 +20,6 @@
     padding: 10px;
 }
 
-.card:hover {
-    background: var(--highlight-main-bg-color);
-}
-
 .leftcard {
     padding: 5px;
     font-size: 18px;


### PR DESCRIPTION
The change of color on hover was confusing for users and made the card seem interactable when it is not.
